### PR TITLE
dropdown runs on change instead of submit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <section id="search-section" class="section">
       <div class="container">
       <form id="covid-form"></form>
-          <label for="name">Search for a State: </label><br>
+          <label for="name">Select a State: </label><br>
           <!--States drop down-->
           <select id='states'>
               <option value="AK">Alaska</option>
@@ -74,7 +74,11 @@
     
             <!--<input id="state-input" type="text" name="State" placeholder="Enter 2 letters" > --> 
             <link rel="stylesheet" href="style.css"></link>
+         
+          <!-- Submit button will not be needed if jquery handler runs when select dropdown is updated     
             <input id="add-state" type="submit" value="Search">
+           -->  
+
         </form>
             </div>
         </section>
@@ -112,7 +116,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
 
     <script type="text/javascript">
-        $("#add-state").on("click", function (event) {
+        $("#states").on("change", function (event) {
             // event.preventDefault() prevents the form from trying to submit itself.
 
             event.preventDefault();


### PR DESCRIPTION
I noticed that only 2 lines would need to be changed in order to eliminate the need for a submit button, so I'm proposing the change in this pull request. Using the "change" jquery event handler on the select box means that the submit button would not be needed, and saves an extra click each time a user wants to view data for a state. 

I kept this branch separate from the other that I'm using to make other css and html updates, because this update is necessary to meet any of the core requirements, and because it might require closer review since it includes a change to a jquery selector.  

I also updated one line of text, text above the select element, just for clarity since the update to using a select element to choose a state.
![project-1-selector-change](https://user-images.githubusercontent.com/10150394/100187062-45352080-2eb5-11eb-86e6-aa54d96f15d2.PNG)
