### PR TITLE
state script runs when select element option is changed

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
               <option value="WV">West Virgina</option>
               <option value="WY">Wyoming</option>
                </select>
-            <input class="button" id="add-state" type="submit" value="Search">
+           <!-- This commented-out input not needed if select runs on change event.  <input class="button" id="add-state" type="submit" value="Search"> -->
         </div>
         </form>
         
@@ -193,7 +193,7 @@
         };
 
         //Onclick for choosing a state from the drop down menu 
-        $("#add-state").on("click", function (event) {
+        $("#states").on("change", function (event) {
             // event.preventDefault() prevents the form from trying to submit itself.
 
             event.preventDefault();


### PR DESCRIPTION
This only required a very small change to the current script.  jQuery handler listens to select element instead of submit input element. Listens for change event instead of click event.  Also commented out the submit button, because it will serve no purpose if the select box change runs the API updates.

![image](https://user-images.githubusercontent.com/10150394/101070276-209e1000-3569-11eb-8bd8-1feaab87b46e.png)
