### PR TITLE
state script runs on select change instead of submit click

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
               <option value="WV">West Virgina</option>
               <option value="WY">Wyoming</option>
                </select>
-            <input class="button" id="add-state" type="submit" value="Search">
+           <!--  <input class="button" id="add-state" type="submit" value="Search">  -->
         </div>
         </form>
         
@@ -193,7 +193,7 @@
         };
 
         //Onclick for choosing a state from the drop down menu 
-        $("#add-state").on("click", function (event) {
+        $("#states").on("change", function (event) {
             // event.preventDefault() prevents the form from trying to submit itself.
 
             event.preventDefault();


### PR DESCRIPTION
This only required a very small change to the current script.  jQuery handler listens to select element instead of submit input element. Listens for change event instead of click event.  Also commented out the submit button, because it will serve no purpose if the select box change runs the API updates.

![image](https://user-images.githubusercontent.com/10150394/101073268-2e559480-356d-11eb-9805-0207eb960556.png)
